### PR TITLE
fix docstring for Machine.config

### DIFF
--- a/machine/machine.py
+++ b/machine/machine.py
@@ -75,7 +75,7 @@ class Machine:
         Args:
             machine: The machine name
         Returns:
-            tuple: tlscacert, tlscert, tlskey, host
+            dict: base_url, tls
         """
         cmd = ["config", machine]
         regexp = """(--tlsverify\n)?--tlscacert="(.+)"\n--tlscert="(.+)"\n--tlskey="(.+)"\n-H=(.+)"""


### PR DESCRIPTION
This PR updates the docstring for `Machine.config` (d8615b43413178d7af59d0516215366cd35ae8c2 ).

Could you also please update `version.py` and upload to the PyPI repo?
