### PR TITLE
Updated to use 'docker' module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ usage
      import machine
      import docker
      m = machine.Machine(path="/usr/local/bin/docker-machine")
-     client = docker.Client(**m.config(machine='default'))
+     client = docker.APIClient(**m.config(machine='default'))
      client.ping()
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 __version__ = "0.2.2"
 
 install_requires = [
-    'docker-py',
+    'docker',
 ]
 
 setup(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -43,7 +43,7 @@ class TestCommands(unittest.TestCase):
 
     def test_config(self):
         config = self.machine.config(machine=TEST_MACHINE)
-        client = docker.Client(**config)
+        client = docker.APIClient(**config)
         self.assertTrue(client.ping())
 
 


### PR DESCRIPTION
No longer use obsolete 'docker-py' version

The Python 'docker' module is now at version 2.2.1 and has changed significantly since the 'docker-py' 1.10 version.

This minor change allows python-docker-machine to work with the current module.

Note: previously installing python-docker-machine was rendering existing 'docker' module unusable as 'docker-py' would be installed.