### PR TITLE
Fix last buggy entry of Machine.ls() output

### DIFF
--- a/machine/machine.py
+++ b/machine/machine.py
@@ -146,7 +146,7 @@ class Machine:
         cmd = ["ls", "-f", fields]
         stdout, stderr, errorcode = self._run(cmd)
         machines = []
-        for line in stdout.split("\n"):
+        for line in stdout.strip().split("\n"):
             machine = {LS_FIELDS[index]: value for index, value in enumerate(line.split(seperator))}
             machines.append(machine)
         return machines

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -64,7 +64,8 @@ class TestCommands(unittest.TestCase):
         self.machine.kill(machine=TEST_MACHINE)
 
     def test_ls(self):
-        self.machine.ls()
+        for m in self.machine.ls():
+            self.assertNotEqual(m['Name'], '')
 
     def test_provision(self):
         self.machine.provision(machine=TEST_MACHINE)


### PR DESCRIPTION
Fix for https://github.com/gijzelaerr/python-docker-machine/issues/13

Machine.ls() generate buggy last entry `{'Name': u''}`
It comes from empty line after `stdout.split("\n")`

```
In [15]: '1\n2\n'.split('\n')
Out[15]: ['1', '2', '']
```

Use strip() to chop trailing '\n'